### PR TITLE
Change iOS work-around to not break Windows. Fixes #2.

### DIFF
--- a/src/main/java/com/ledger/u2f/U2FApplet.java
+++ b/src/main/java/com/ledger/u2f/U2FApplet.java
@@ -46,7 +46,6 @@ public class U2FApplet extends Applet implements ExtendedLength {
     private static final byte FIDO_INS_SIGN = (byte)0x02;
     private static final byte FIDO_INS_VERSION = (byte)0x03;
     private static final byte ISO_INS_GET_DATA = (byte)0xC0;
-    private static final byte FIDO2_INS_NFCCTAP_MSG = (byte)0x10;
 
     private static final byte FIDO_INS_RESET_ATTEST = (byte)0x55;
 
@@ -93,8 +92,6 @@ public class U2FApplet extends Applet implements ExtendedLength {
 
     private static final byte INSTALL_FLAG_DISABLE_USER_PRESENCE = (byte)0x01;
     private static final byte INSTALL_FLAG_ALLOW_RESET_ATTEST = (byte)0x02;
-
-    private static final byte CTAP1_ERR_INVALID_COMMAND = (byte)0x01;
 
     // Parameters
     // 1 byte : flags
@@ -497,11 +494,7 @@ public class U2FApplet extends Applet implements ExtendedLength {
         }
 
         if ((buffer[ISO7816.OFFSET_CLA] & (byte)0x80) == (byte)0x80) {
-            if (buffer[ISO7816.OFFSET_INS] == FIDO2_INS_NFCCTAP_MSG) {
-                handleCtap2(apdu);
-            } else {
-                ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
-            }
+            ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
         } else {
             switch (buffer[ISO7816.OFFSET_INS]) {
                 case FIDO_INS_ENROLL:
@@ -523,22 +516,6 @@ public class U2FApplet extends Applet implements ExtendedLength {
                     ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
             }
         }
-    }
-
-    private void
-    handleCtap2(APDU apdu)
-    {
-        // We don't actually support CTAP2, so we always
-        // return CTAP1_ERR_INVALID_COMMAND.
-        final byte[] buffer = apdu.getBuffer();
-        apdu.setIncomingAndReceive();
-        short dataOffset = apdu.getOffsetCdata();
-
-        short len = 0;
-
-        buffer[len++] = CTAP1_ERR_INVALID_COMMAND;
-
-        apdu.setOutgoingAndSend((short)0, len);
     }
 
     public static void install (byte bArray[], short bOffset, byte bLength) throws ISOException {


### PR DESCRIPTION
Apparently the iOS work-around, as implemented in commit 8b58c4cdcae, has the side effect of causing Windows to reject the authenticator entirely—see issue #2.

However, it was found that if we return `SW_INS_NOT_SUPPORTED` for the FIDO2 NFC CTAP command (instead of `SW_CLA_NOT_SUPPORTED` or mimicking a CTAP2 error response), we end up with a CTAP1 authenticator that works on both iOS and Windows.

So this change reverts the previous work-around for iOS and makes sure that we return `SW_INS_NOT_SUPPORTED` for any CLA with the highest bit set.

Thanks go to Anurag Sharma (@annu0412) for discovering this issue.